### PR TITLE
Tree from preorder

### DIFF
--- a/tree.py
+++ b/tree.py
@@ -54,6 +54,18 @@ class SyntaxNode(object):
         else:
             return False
 
+    def preorder_node(self, node_list: list) -> list:
+        if self.n_args == 2:
+            self.left = SyntaxNode(node_list.pop(0))
+            node_list = self.left.preorder_node(node_list)
+            self.right = SyntaxNode(node_list.pop(0))
+            return self.right.preorder_node(node_list)
+        elif self.n_args == 1:
+            self.left = SyntaxNode(node_list.pop(0))
+            return self.left.preorder_node(node_list)
+        else:
+            return node_list
+
     def get_function(self, X: torch.Tensor) -> Callable:
         if self.n_args == 1:
             return self.op(self.left.get_function(X))
@@ -82,6 +94,12 @@ def get_expression(root:SyntaxNode) -> str:
     else:
         return '('+ get_expression(root.left) + root.value + get_expression(root.right) + ')'       
 
+def tree_from_preorder(preorder : list) -> SyntaxNode:
+    root = preorder.pop(0)
+    for node_id in preorder:
+        root.add_node(node_id)
+    return root
+
 if __name__ == '__main__':
     # lambda x: exp(ax + b)
     root = SyntaxNode("exp") # exp
@@ -94,6 +112,10 @@ if __name__ == '__main__':
     print(root.get_function(x))
     print(root.get_preorder())
     print(get_expression(root))
+    print('reconstruction test')
+    root2 = SyntaxNode("exp")
+    assert root2.preorder_node(['+','*','const','var','const']) == []
+    print(get_expression(root2))
 
 
     

--- a/tree.py
+++ b/tree.py
@@ -54,15 +54,15 @@ class SyntaxNode(object):
         else:
             return False
 
-    def preorder_node(self, node_list: list) -> list:
+    def from_preorder(self, node_list: list) -> list:
         if self.n_args == 2:
             self.left = SyntaxNode(node_list.pop(0))
-            node_list = self.left.preorder_node(node_list)
+            node_list = self.left.from_preorder(node_list)
             self.right = SyntaxNode(node_list.pop(0))
-            return self.right.preorder_node(node_list)
+            return self.right.from_preorder(node_list)
         elif self.n_args == 1:
             self.left = SyntaxNode(node_list.pop(0))
-            return self.left.preorder_node(node_list)
+            return self.left.from_preorder(node_list)
         else:
             return node_list
 
@@ -114,7 +114,7 @@ if __name__ == '__main__':
     print(get_expression(root))
     print('reconstruction test')
     root2 = SyntaxNode("exp")
-    assert root2.preorder_node(['+','*','const','var','const']) == []
+    assert root2.from_preorder(['+','*','const','var','const']) == []
     print(get_expression(root2))
 
 


### PR DESCRIPTION
I added the ability to reconstruct the tree from preorder using root.from_preorder([list of node identifiers]).

Feel free to suggest any changes if there's a more elegant/performant way to do this.