### PR TITLE
Syntax checking refactor

### DIFF
--- a/model.py
+++ b/model.py
@@ -41,46 +41,6 @@ class SyntaxTreeLSTM(nn.Module):
             out = self.conv3(out)
             out = self.flatten(out)
             return out.shape[-1]
-    
-    # def stop_criterion(self, tree: SyntaxNode) -> bool:
-    #     '''Test to see if tree is complete'''
-    #     leaf_list = tree.get_leaf_nodes()
-    #     for leaf in leaf_list:
-    #         if leaf.n_args != 0:
-    #             return False
-    #     return True
-
-
-    # def update_tree(self, tree: SyntaxNode, model_dist: torch.tensor) -> Tuple[SyntaxTree, 
-    #                                                                            torch.tensor,
-    #                                                                            torch.tensor]:
-    #     '''Sample new token from distribution, ignore illegal choices, update tree'''
-    #     # make model_dist probabilities
-    #     model_dist = nf.softmax(model_dist, axis=0)
-    #     # get last node in tree
-    #     last_node = tree.get_last()
-    #     # get list of node names thay may not follow the last node
-    #     illegal_nodes = last_node.illegal[last_node.value]
-    #     # convert node names to node indices
-    #     illegal_nodes = [OP_NAMES.find(name) for name in illegal_nodes]
-    #     # zero out the logit probabilities for illegal next nodes
-    #     for index in illegal_nodes:
-    #         model_dist[index] = 0
-    #     # get the tree preorder
-    #     preorder = tree.get_preorder()
-    #     # sample a new node from the logit distribution and add to preorder
-    #     dist = Categorical(model_dist)
-    #     action = dist.sample()
-    #     log_prob = dist.log_prob(action)
-    #     preorder.append(OP_NAMES[action.item()])
-    #     # reconstruct tree from the updated preorder
-    #     tree = tree_from_preorder(preorder)
-    #     return tree, action, log_prob
-
-
-
-    # def get_parent_sibling(self, tree: SyntaxNode) -> torch.tensor:
-    #     '''take tree and return the parent and sibling of next node in traversal'''
         
 
     def forward(self, 

--- a/train.py
+++ b/train.py
@@ -87,10 +87,12 @@ def main(args):
             #       - improve illegal node checking to incorporate greater
             #       context
 
-            # query parent of next node
-            parent_node = tree.get_last()
+            # get illegal set
+            print(get_expression_refactor(tree))
+            illegal_set = get_illegal_set(tree)
+            print(f'step: {step}, illegal_set: {illegal_set}')
             # convert illegal node names into indices
-            illegal_nodes = [list(SyntaxNode.op_list.keys()).index(node) for node in parent_node.illegal]
+            illegal_nodes = [list(SyntaxNode.op_list.keys()).index(node) for node in illegal_set]
             # zero probability of illegal nodes
             for index in illegal_nodes:
                 pi_dist[0, index] = 0
@@ -100,7 +102,10 @@ def main(args):
             node = pi_dist_obj.sample()
 
             # get next state, reward, done from environment based on action
+            print(list(SyntaxNode.op_list.keys())[node])
             tree.append(list(SyntaxNode.op_list.keys())[node], hidden_state_1.detach())
+            print(get_expression_refactor(tree))
+            print(get_illegal_set(tree))
             # NOTE:
             # during exploration, this hidden state can be detached from computation graph.
             # in the policy update, the tree will need to be repopulated with 'live'
@@ -142,9 +147,9 @@ def main(args):
                         #exceeds_max_depth = True
                 else:
                     print('Function not parameterized')
-                    #reward = 1 / (1 + torch.mean(torch.pow(tree.get_function(x_test[0,0].cpu()) - x_test[0,1].cpu(), 2)))
-                    #print(f'reward: {reward}')
-                    reward = torch.tensor(-1)
+                    reward = 1 / (1 + torch.mean(torch.pow(tree.get_function(x_test[0,0].cpu()) - x_test[0,1].cpu(), 2)))
+                    print(f'reward: {reward}')
+                    #reward = torch.tensor(-1)
                     exit = True
                     #exceeds_max_depth = True
             elif get_tree_depth(tree) >= args.max_depth:

--- a/tree.py
+++ b/tree.py
@@ -286,20 +286,22 @@ def child_of(node: SyntaxNode, nodetypes: set) -> bool:
 def get_illegal_set(root: SyntaxNode) -> set:
     parent = root.get_last()
     sibling = root.get_sibling()
-    illegal_set = SyntaxNode.illegal[parent.value]
+    # copying the set is important, otherwise we modify the illegal sets for
+    # each node globally
+    illegal_nodes = SyntaxNode.illegal[parent.value].copy()
     if parent.value in {'+', '-', '/'}:
         if sibling != None:
             if sibling.value in {'const', 'var'}:
-                illegal_set.add(sibling.value)
+                illegal_nodes.add(sibling.value)
     if parent.value == '*':
         if sibling != None:
             if sibling.value in {'const', 'log', 'exp'}:
-                illegal_set.add(sibling.value)
+                illegal_nodes.add(sibling.value)
     if child_of(parent, {'sin', 'cos', 'log', 'exp'}):
-        illegal_set |= {'sin', 'cos', 'log', 'exp'}
+        illegal_nodes |= {'sin', 'cos', 'log', 'exp'}
         if parent.value in {'sin', 'cos', 'log', 'exp'}:
-            illegal_set.add('const')
-    return illegal_set
+            illegal_nodes.add('const')
+    return illegal_nodes
 
 if __name__ == '__main__':
     print('reconstruction test:')


### PR DESCRIPTION
Refactored the syntax checking system, now has more capabilities for avoiding simple constant operations. Needs more work on detecting operations that simplify such as log(x) + log(x). Figure out what additions are not allowed in-order to make the two subtrees of a grandparent node not-identical?